### PR TITLE
feat: add `idle` value to DeliveryState

### DIFF
--- a/MailerQ/DeliveryState.cs
+++ b/MailerQ/DeliveryState.cs
@@ -89,6 +89,10 @@
         /// <summary>
         /// The full mime data followed by a dot has been sent
         /// </summary>
-        Message
+        Message,
+        /// <summary>
+        /// Email was loaded in an event loop that never becomes idle
+        /// </summary>
+        Idle,
     }
 }


### PR DESCRIPTION
Related to DM-177

The `idle` value for `DeliveryState` is not documented, that is why was not not included before and cause error when we analyze the `ResultMessage`.
I created a issue to report missing documentation at https://github.com/CopernicaMarketingSoftware/Documentation/issues/38