### PR TITLE
feat: add new rewrite value for DeliveryState

### DIFF
--- a/MailerQ/DeliveryState.cs
+++ b/MailerQ/DeliveryState.cs
@@ -94,5 +94,9 @@
         /// Email was loaded in an event loop that never becomes idle
         /// </summary>
         Idle,
+        /// <summary>
+        /// Email was modified by a rewrite rule
+        /// </summary>
+        Rewrite,
     }
 }


### PR DESCRIPTION
When set a Rewrite Rule in MailerQ Web Manager Console to Delay a message, the result has the `DeliveryState` rewrite, and generate a `RetryResultMessage` with *error 4.0.0*

This state is not documented in https://www.mailerq.com/documentation/5.8/json-results