### PR TITLE
[DM-346] Add support for external storage

### DIFF
--- a/MailerQ.MessageStorage.Test/MailerQ.MessageStorage.Test.csproj
+++ b/MailerQ.MessageStorage.Test/MailerQ.MessageStorage.Test.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MailerQ.MessageStorage\MailerQ.MessageStorage.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MailerQ.MessageStorage.Test/MessageStorageTest.cs
+++ b/MailerQ.MessageStorage.Test/MessageStorageTest.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.Extensions.Options;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MailerQ.MessageStorage.Test
+{
+    public class MessageStorageTest
+    {
+        public static IOptions<MessageStorageSettings> CreateOptions(string uri)
+        {
+            var messageStorageSettings = new MessageStorageSettings { Url = uri };
+            return Options.Create(messageStorageSettings);
+        }
+
+        [InlineData("")]
+        [InlineData("not uri")]
+        [Theory]
+        public void Constructor_should_throw_exception_with_invalid_uri(string uri)
+        {
+            // Arrange
+            var options = CreateOptions(uri);
+
+            // Act
+            var ex = Assert.Throws<ArgumentException>(() => new MessageStorage(options));
+
+            // Assert
+            Assert.Contains("has invalid value", ex.Message);
+        }
+
+
+        [InlineData("http://server/path/to/directory")]
+        [InlineData("https://server/path/to/directory")]
+        [InlineData("ftp://path/to/directory")]
+        [InlineData("file:///path/to/directory")]
+        [InlineData("sqlite:///path/to/database/file")]
+        [Theory]
+        public void Constructor_should_throw_exception_with_unsupported_engine_uri(string uri)
+        {
+            // Arrange
+            var options = CreateOptions(uri);
+            var expected = $"{nameof(MessageStorageSettings)}.{nameof(MessageStorageSettings.Url)} has an unsupported message storage scheme";
+
+            // Act
+            var exception = Assert.Throws<ArgumentException>(() => new MessageStorage(options));
+
+            // Assert
+            Assert.Equal(expected, exception.Message);
+        }
+
+        [InlineData("couchbase://password@hostname/bucketname")]
+        [InlineData("mysql://user:password@hostname/databasename")]
+        [InlineData("postgresql://user:password@hostname/databasename")]
+        [Theory]
+        public void Create_should_throw_exception_with_not_implemented_supported_engine_uri(string uri)
+        {
+            // Arrange
+            var options = CreateOptions(uri);
+            var expected = "message storage engine is not implement yet.";
+
+            // Act
+            var ex = Assert.Throws<NotImplementedException>(() => new MessageStorage(options));
+
+            // Assert
+            Assert.Contains(expected, ex.Message);
+        }
+    }
+}

--- a/MailerQ.MessageStorage/IMessageStorage.cs
+++ b/MailerQ.MessageStorage/IMessageStorage.cs
@@ -1,0 +1,10 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace MailerQ.MessageStorage
+{
+    public interface IMessageStorage
+    {
+        Task<string> InsertAsync(string message, CancellationToken cancellationToken = default);
+    }
+}

--- a/MailerQ.MessageStorage/MailerQ.MessageStorage.csproj
+++ b/MailerQ.MessageStorage/MailerQ.MessageStorage.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="3.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/MailerQ.MessageStorage/MailerQ.MessageStorage.csproj
+++ b/MailerQ.MessageStorage/MailerQ.MessageStorage.csproj
@@ -3,6 +3,13 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Authors>Making Sense</Authors>
+    <Company>Making Sense</Company>
+    <Description>Support for Mime External Storage in MailerQ .Net SDK</Description>
+    <PackageId>MailerQ.MessageStorage</PackageId>
+    <Product>MailerQ .Net SDK</Product>
+    <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MailerQ.MessageStorage/MailerQ.MessageStorage.csproj
+++ b/MailerQ.MessageStorage/MailerQ.MessageStorage.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.0.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.10.2" />
   </ItemGroup>
 
 </Project>

--- a/MailerQ.MessageStorage/MailerQ.MessageStorage.csproj
+++ b/MailerQ.MessageStorage/MailerQ.MessageStorage.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MailerQ.MessageStorage/MessageStorage.cs
+++ b/MailerQ.MessageStorage/MessageStorage.cs
@@ -30,6 +30,8 @@ namespace MailerQ.MessageStorage
         {
             switch (storageEngine)
             {
+                case MessageStorageEngine.MongoDB:
+                    return new MongoMessageStorage(uri);
                 default:
                     throw new NotImplementedException($"{storageEngine} message storage engine is not implement yet.");
             }

--- a/MailerQ.MessageStorage/MessageStorage.cs
+++ b/MailerQ.MessageStorage/MessageStorage.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.Extensions.Options;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MailerQ.MessageStorage
+{
+    public class MessageStorage : IMessageStorage
+    {
+        private readonly IMessageStorage storage;
+
+        public MessageStorage(IOptions<MessageStorageSettings> options)
+        {
+            var uri = options.Value.Url;
+            int schemeSeparatorIndex = uri.IndexOf(@"://");
+            if (schemeSeparatorIndex <= 0)
+            {
+                throw new ArgumentException($"{nameof(MessageStorageSettings)}.{nameof(MessageStorageSettings.Url)} has invalid value");
+            }
+
+            var scheme = uri.Remove(schemeSeparatorIndex);
+            if (!Enum.TryParse(scheme, ignoreCase: true, out MessageStorageEngine storageScheme))
+            {
+                throw new ArgumentException($"{nameof(MessageStorageSettings)}.{nameof(MessageStorageSettings.Url)} has an unsupported message storage scheme");
+            }
+            storage = CreateConcretStorage(storageScheme, uri);
+        }
+
+        private IMessageStorage CreateConcretStorage(MessageStorageEngine storageEngine, string uri)
+        {
+            switch (storageEngine)
+            {
+                default:
+                    throw new NotImplementedException($"{storageEngine} message storage engine is not implement yet.");
+            }
+        }
+
+        public Task<string> InsertAsync(string message, CancellationToken cancellationToken = default)
+        {
+            return storage.InsertAsync(message, cancellationToken);
+        }
+    }
+}

--- a/MailerQ.MessageStorage/MessageStorageEngine.cs
+++ b/MailerQ.MessageStorage/MessageStorageEngine.cs
@@ -1,0 +1,10 @@
+﻿namespace MailerQ.MessageStorage
+{
+    public enum MessageStorageEngine
+    {
+        MongoDB,
+        CouchBase,
+        MySql,
+        PostgreSql,
+    }
+}

--- a/MailerQ.MessageStorage/MessageStorageSettings.cs
+++ b/MailerQ.MessageStorage/MessageStorageSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace MailerQ.MessageStorage
+{
+    public class MessageStorageSettings
+    {
+        public string Url { get; set; }
+    }
+}

--- a/MailerQ.MessageStorage/MongoMessageStorage.cs
+++ b/MailerQ.MessageStorage/MongoMessageStorage.cs
@@ -1,0 +1,52 @@
+﻿using MongoDB.Bson;
+using MongoDB.Driver;
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MailerQ.MessageStorage
+{
+    internal class MongoMessageStorage : IMessageStorage
+    {
+        const int MessageMaxSuppportedSize = 15728640; // 15 MB
+        const int DaysToExpire = 7;
+        const string DataBase = "mailerq";
+        readonly string Collection = "message";
+
+        readonly IMongoCollection<BsonDocument> messages;
+
+        public MongoMessageStorage(string url)
+        {
+            var mongoUrl = MongoUrl.Create(url);
+            var mongoClient = new MongoClient(mongoUrl);
+            var database = mongoClient.GetDatabase(mongoUrl.DatabaseName ?? DataBase);
+            messages = database.GetCollection<BsonDocument>(Collection);
+        }
+
+        public async Task<string> InsertAsync(string message, CancellationToken cancellationToken = default)
+        {
+            var now = DateTime.UtcNow;
+            var key = ObjectId.GenerateNewId(now).ToString();
+
+            var encodedMessage = Encoding.UTF8.GetBytes(message);
+
+            if (encodedMessage.Length >= MessageMaxSuppportedSize)
+            {
+                // TODO split into multiple documents to allow any message size
+                throw new NotSupportedException($"Message is to big, split is not suppported yet. Size should be less than {MessageMaxSuppportedSize} bytes.");
+            }
+
+            var mime = new BsonDocument {
+                { "_id", key },
+                { "value", encodedMessage  },
+                { "expire", now.AddDays(DaysToExpire) },
+                { "modified", now },
+                { "encoding", "identity" }
+            };
+
+            await messages.InsertOneAsync(mime, null, cancellationToken);
+            return key;
+        }
+    }
+}

--- a/MailerQ.sln
+++ b/MailerQ.sln
@@ -13,6 +13,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MailerQ.MessageStorage", "MailerQ.MessageStorage\MailerQ.MessageStorage.csproj", "{1F071AF9-3476-4244-AD40-A00E805ABDD6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MailerQ.MessageStorage.Test", "MailerQ.MessageStorage.Test\MailerQ.MessageStorage.Test.csproj", "{1739D0BC-473F-4FE9-ABAE-EA70F3B0173C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -35,6 +39,30 @@ Global
 		{B6641256-543C-4D68-93CC-219366A2C099}.Release|x64.Build.0 = Release|Any CPU
 		{B6641256-543C-4D68-93CC-219366A2C099}.Release|x86.ActiveCfg = Release|Any CPU
 		{B6641256-543C-4D68-93CC-219366A2C099}.Release|x86.Build.0 = Release|Any CPU
+		{1F071AF9-3476-4244-AD40-A00E805ABDD6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F071AF9-3476-4244-AD40-A00E805ABDD6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F071AF9-3476-4244-AD40-A00E805ABDD6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1F071AF9-3476-4244-AD40-A00E805ABDD6}.Debug|x64.Build.0 = Debug|Any CPU
+		{1F071AF9-3476-4244-AD40-A00E805ABDD6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1F071AF9-3476-4244-AD40-A00E805ABDD6}.Debug|x86.Build.0 = Debug|Any CPU
+		{1F071AF9-3476-4244-AD40-A00E805ABDD6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F071AF9-3476-4244-AD40-A00E805ABDD6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1F071AF9-3476-4244-AD40-A00E805ABDD6}.Release|x64.ActiveCfg = Release|Any CPU
+		{1F071AF9-3476-4244-AD40-A00E805ABDD6}.Release|x64.Build.0 = Release|Any CPU
+		{1F071AF9-3476-4244-AD40-A00E805ABDD6}.Release|x86.ActiveCfg = Release|Any CPU
+		{1F071AF9-3476-4244-AD40-A00E805ABDD6}.Release|x86.Build.0 = Release|Any CPU
+		{1739D0BC-473F-4FE9-ABAE-EA70F3B0173C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1739D0BC-473F-4FE9-ABAE-EA70F3B0173C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1739D0BC-473F-4FE9-ABAE-EA70F3B0173C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1739D0BC-473F-4FE9-ABAE-EA70F3B0173C}.Debug|x64.Build.0 = Debug|Any CPU
+		{1739D0BC-473F-4FE9-ABAE-EA70F3B0173C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1739D0BC-473F-4FE9-ABAE-EA70F3B0173C}.Debug|x86.Build.0 = Debug|Any CPU
+		{1739D0BC-473F-4FE9-ABAE-EA70F3B0173C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1739D0BC-473F-4FE9-ABAE-EA70F3B0173C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1739D0BC-473F-4FE9-ABAE-EA70F3B0173C}.Release|x64.ActiveCfg = Release|Any CPU
+		{1739D0BC-473F-4FE9-ABAE-EA70F3B0173C}.Release|x64.Build.0 = Release|Any CPU
+		{1739D0BC-473F-4FE9-ABAE-EA70F3B0173C}.Release|x86.ActiveCfg = Release|Any CPU
+		{1739D0BC-473F-4FE9-ABAE-EA70F3B0173C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Related to: [DM-346](https://makingsense.atlassian.net/browse/DM-346)

This PR is to add support for store mime messages in a external storage, to be retrieved by *MailerQ* just before perform the delivery.

Actually MailerQ support:
- MongoDB
- CouchDB
- MySq
- PostgresSql
- Sqlite
- Directory

The first engine supported is **MongoDB** (it is that I need now), 

To simplify the implementation, by the moment, `MongoMessageStorage` has limited the size of the message to 15MB that is a safe value for put into a single document in Mongo that support 16 MB as max size.