### PR TITLE
fix(MongoDB): rename default collection name

### DIFF
--- a/MailerQ/MessageStore/MongoDBMessageStorage.cs
+++ b/MailerQ/MessageStore/MongoDBMessageStorage.cs
@@ -12,7 +12,7 @@ namespace MailerQ.MessageStore
         private const int MessageMaxSuppportedSize = 15728640; // 15 MB
         private const int DaysToExpire = 7;
         private const string DataBase = "mailerq";
-        private readonly string Collection = "message";
+        private readonly string Collection = "mime";
         private readonly IMongoCollection<BsonDocument> messages;
 
         public MongoDBMessageStorage(string url)


### PR DESCRIPTION
The idea is use mailerq/mime as default database/collection all message should be a mime or mime template