### PR TITLE
[DM-358] feat: publish OutgoingMessage with Priority

### DIFF
--- a/MailerQ/Core/QueueManager.cs
+++ b/MailerQ/Core/QueueManager.cs
@@ -29,7 +29,7 @@ namespace MailerQ
 
         public void Publish(OutgoingMessage outgoingMessage, string queueName)
         {
-            var message = new Message<OutgoingMessage>(outgoingMessage);
+            var message = CreateMessage(outgoingMessage);
             bus.Publish(Exchange.GetDefault(), queueName, false, message);
         }
 
@@ -41,8 +41,19 @@ namespace MailerQ
 
         public async Task PublishAsync(OutgoingMessage outgoingMessage, string queueName)
         {
-            var message = new Message<OutgoingMessage>(outgoingMessage);
+            var message = CreateMessage(outgoingMessage);
             await bus.PublishAsync(Exchange.GetDefault(), queueName, false, message);
+        }
+
+        private static Message<OutgoingMessage> CreateMessage(OutgoingMessage outgoingMessage)
+        {
+            var message = new Message<OutgoingMessage>(outgoingMessage);
+            if (outgoingMessage.Priority.HasValue)
+            {
+                message.Properties.Priority = (byte)outgoingMessage.Priority;
+                message.Properties.PriorityPresent = outgoingMessage.Priority.HasValue;
+            }
+            return message;
         }
 
         public IDisposable Subscribe<T>(Action<T> action) where T : OutgoingMessage


### PR DESCRIPTION
Related to: [DM-358](https://makingsense.atlassian.net/browse/DM-358)

Until now, the `OutgoingMessage` was publish without Priority into the Queue, the priority only toke effect after the message was consumed by MailerQ.

Now, if the priority is set in. The message will has the priority from the begin when is publish in the first time to Rabbit.