### PR TITLE
ci(github): pack nuget only when build a tag

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -2,7 +2,6 @@ name: .NET Core
 
 on:
   push:
-    branches: [ master ]
     tags: '**'
   pull_request:
     branches: [ master ]


### PR DESCRIPTION
Until now was trying pack nuget on merge to *master* too.