### PR TITLE
[DM-131] Add MailerQ Rest API types

### DIFF
--- a/MailerQ/IncomingMessage.cs
+++ b/MailerQ/IncomingMessage.cs
@@ -48,6 +48,11 @@ namespace MailerQ
         public string MTA { get; set; }
 
         public bool Report { get; set; }
+
+        /// <summary>        
+        /// Rest API info (only used when received from Rest Api)
+        /// </summary>
+        public RestApiInfo Http { get; set; }
     }
 
     [Queue(Conventions.QueueName.Reports)]

--- a/MailerQ/RestApi/Error.cs
+++ b/MailerQ/RestApi/Error.cs
@@ -1,0 +1,54 @@
+﻿using Newtonsoft.Json;
+
+namespace MailerQ.RestApi
+{
+    /// <summary>
+    /// Using this endpoint MailerQ allows you to intercept it and forcing an error on any combination of pool/mta and domain.
+    /// </summary>
+    [JsonObject(
+    NamingStrategyType = typeof(LowercaseNamingStrategy),
+    ItemNullValueHandling = NullValueHandling.Ignore
+    )]
+    public class Error
+    {
+        /// <summary>
+        /// Numeric error code between 200 and 599 (smtp error codes).
+        /// </summary>
+        public int Code { get; set; }
+
+        /// <summary>
+        /// Extended SMTP error code, e.g. 5.7.1.
+        /// </summary>
+        public string Extended { get; set; }
+
+        /// <summary>
+        /// Description to put in the message result.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Pool that the error applies to.
+        /// </summary>
+        public string Pool { get; set; }
+
+        /// <summary>
+        /// MTA IP that the error applies to.
+        /// </summary>
+        public string Mta { get; set; }
+
+        /// <summary>
+        /// Domain that the error applies to.
+        /// </summary>
+        public string Domain { get; set; }
+
+        /// <summary>
+        /// The tag that the error applies to.
+        /// </summary>
+        public string Tag { get; set; }
+
+        /// <summary>
+        /// Whether or not this error is for the entire cluster or only this instance.
+        /// </summary>
+        public bool Cluster { get; set; }
+    }
+}

--- a/MailerQ/RestApi/Error.cs
+++ b/MailerQ/RestApi/Error.cs
@@ -3,17 +3,18 @@
 namespace MailerQ.RestApi
 {
     /// <summary>
-    /// Using this endpoint MailerQ allows you to intercept it and forcing an error on any combination of pool/mta and domain.
+    /// Define control over delivery flow to intercept it and forcing an error on any combination of pool/mta and domain.
     /// </summary>
     [JsonObject(
-    NamingStrategyType = typeof(LowercaseNamingStrategy),
-    ItemNullValueHandling = NullValueHandling.Ignore
+        NamingStrategyType = typeof(LowercaseNamingStrategy),
+        ItemNullValueHandling = NullValueHandling.Ignore
     )]
     public class Error
     {
         /// <summary>
         /// Numeric error code between 200 and 599 (smtp error codes).
         /// </summary>
+        [JsonProperty(Required = Required.Always)]
         public int Code { get; set; }
 
         /// <summary>

--- a/MailerQ/RestApi/Pause.cs
+++ b/MailerQ/RestApi/Pause.cs
@@ -3,7 +3,7 @@
 namespace MailerQ.RestApi
 {
     /// <summary>
-    /// Using this endpoint MailerQ allows you to pause almost any combination of pool/mta and domain/ip.
+    /// Define control over delivery flow, to pause almost any combination of pool/mta and domain/ip.
     /// </summary>
     [JsonObject(
        NamingStrategyType = typeof(LowercaseNamingStrategy),

--- a/MailerQ/RestApi/Pause.cs
+++ b/MailerQ/RestApi/Pause.cs
@@ -1,0 +1,44 @@
+﻿using Newtonsoft.Json;
+
+namespace MailerQ.RestApi
+{
+    /// <summary>
+    /// Using this endpoint MailerQ allows you to pause almost any combination of pool/mta and domain/ip.
+    /// </summary>
+    [JsonObject(
+       NamingStrategyType = typeof(LowercaseNamingStrategy),
+       ItemNullValueHandling = NullValueHandling.Ignore
+    )]
+    public class Pause
+    {
+        /// <summary>
+        /// Pool that the pause applies to.
+        /// </summary>
+        public string Pool { get; set; }
+
+        /// <summary>
+        /// MTA IP that the pause applies to.
+        /// </summary>
+        public string Mta { get; set; }
+
+        /// <summary>
+        /// Domain that the pause applies to.
+        /// </summary>
+        public string Domain { get; set; }
+
+        /// <summary>
+        /// Remote IP that the pause applies to.
+        /// </summary>
+        public string Ip { get; set; }
+
+        /// <summary>
+        /// The tag that the pause applies to.
+        /// </summary>
+        public string Tag { get; set; }
+
+        /// <summary>
+        /// Whether or not this pause is for the entire cluster or only this instance.
+        /// </summary>
+        public bool Cluster { get; set; }
+    }
+}

--- a/MailerQ/RestApiInfo.cs
+++ b/MailerQ/RestApiInfo.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MailerQ
+{
+    /// <summary>
+    /// Message injected via MailerQ REST API hold information about who connected and the name of the authentication token in the http property.
+    /// </summary>
+    public class RestApiInfo
+    {
+        /// <summary>
+        /// Name of the authentication token
+        /// </summary>
+        public string Authentication { get; set; }
+
+        /// <summary>
+        /// Remote ip who connected
+        /// </summary>
+        public string RemoteIp { get; set; }
+
+        /// <summary>
+        /// Remote port who connected
+        /// </summary>
+        public string RemotePort { get; set; }
+    }
+}


### PR DESCRIPTION
Related to: [DM-131](https://makingsense.atlassian.net/browse/DM-131) and [DM-374](https://makingsense.atlassian.net/browse/DM-374).

In this PR is adding the types of MailerQ Rest API, in order to use the endpoint added in version 5.6.x of MailerQ:
- Errors
- Pauses
- Inject (is the same as `OutgoigMessage`)