### PR TITLE
chore(deps): rollback EasyNetQ to v3.7.1

### DIFF
--- a/MailerQ/MailerQ.csproj
+++ b/MailerQ/MailerQ.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EasyNetQ" Version="5.1.0" />
+    <PackageReference Include="EasyNetQ" Version="3.7.1" />
     <PackageReference Include="MongoDB.Driver" Version="2.10.4" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />


### PR DESCRIPTION
This is the last version that we use before change to Rabbit.Client 5.x version

A rare error that causes rabbit consumers to be disconnected with the `client unexpectedly closed TCP connection` error and the client does not re-establish the connection leaving it in a state where it simply does nothing.
We assume that this is related to the update of the nuget `Rabbit.Client` which was updated to version 6.0 from version 4.0.0 of `EasyNetQ`.