### PR TITLE
refactor: fix typo in priority enum

### DIFF
--- a/MailerQ/Conventions/Priority.cs
+++ b/MailerQ/Conventions/Priority.cs
@@ -4,6 +4,6 @@
     {
         Low,
         Normal,
-        Higth
+        High
     }
 }


### PR DESCRIPTION
Potential BREAKING CHANGE if use the Priority enum from conventional name space