### PR TITLE
Rest api endpoints for v5.8

### DIFF
--- a/MailerQ/RestApi/ExternalIP.cs
+++ b/MailerQ/RestApi/ExternalIP.cs
@@ -1,0 +1,46 @@
+﻿using Newtonsoft.Json;
+
+namespace MailerQ.RestApi
+{
+    /// <summary>
+    /// The protocol sopported to connect to the external server
+    /// </summary>
+    public enum ExternalIpProtocol
+    {
+        /// <summary>
+        /// Network address translation
+        /// </summary>
+        Nat
+    }
+
+    /// <summary>
+    /// External MTA.
+    /// Setting to uses IP address that is not local to the server MailerQ is running on.
+    /// </summary>
+    [JsonObject(
+        NamingStrategyType = typeof(LowercaseNamingStrategy),
+        ItemNullValueHandling = NullValueHandling.Ignore
+    )]
+    public class ExternalIP
+    {
+        /// <summary>
+        /// The external IP address to use for sending
+        /// </summary>
+        [JsonProperty("public_ip", Required = Required.Always)]
+        public string PublicIP { get; set; }
+        /// <summary>
+        /// The local IP address to bind to
+        /// </summary>
+        [JsonProperty("local_ip")]
+        public string LocalIP { get; set; }
+        /// <summary>
+        /// The port to use for the external server
+        /// </summary>
+        [JsonProperty("connect_port")]
+        public int ConnectPort { get; set; }
+        /// <summary>
+        /// The protocol to use to connect to the external server(currently only 'nat' is supported)
+        /// </summary>
+        public ExternalIpProtocol Protocol { get; set; }
+    }
+}

--- a/MailerQ/RestApi/IpPool.cs
+++ b/MailerQ/RestApi/IpPool.cs
@@ -1,0 +1,49 @@
+﻿using Newtonsoft.Json;
+
+namespace MailerQ.RestApi
+{
+    /// <summary>
+    /// Pool of IPs
+    /// MailerQ offers IP Pools for easy management of your sending IP addresses.
+    /// </summary>
+    [JsonObject(
+        NamingStrategyType = typeof(LowercaseNamingStrategy),
+        ItemNullValueHandling = NullValueHandling.Ignore
+    )]
+    public class IpPool
+    {
+        /// <summary>
+        /// The name of the pool
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Description of the pool, for human use.
+        /// </summary>
+        public string Description { get; set; }
+    }
+
+    /// <summary>
+    /// IP Address
+    /// MailerQ offers IP Pools for easy management of your sending IP addresses.
+    /// </summary>
+    [JsonObject(
+        NamingStrategyType = typeof(LowercaseNamingStrategy),
+        ItemNullValueHandling = NullValueHandling.Ignore
+    )]
+    public class IpAddress
+    {
+        /// <summary>
+        /// The IP address
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public string Ip { get; set; }
+        /// <summary>
+        /// The name of the pool
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public string Name { get; set; }
+
+    }
+}

--- a/MailerQ/RestApi/Pause.cs
+++ b/MailerQ/RestApi/Pause.cs
@@ -6,8 +6,8 @@ namespace MailerQ.RestApi
     /// Define control over delivery flow, to pause almost any combination of pool/mta and domain/ip.
     /// </summary>
     [JsonObject(
-       NamingStrategyType = typeof(LowercaseNamingStrategy),
-       ItemNullValueHandling = NullValueHandling.Ignore
+        NamingStrategyType = typeof(LowercaseNamingStrategy),
+        ItemNullValueHandling = NullValueHandling.Ignore
     )]
     public class Pause
     {

--- a/MailerQ/RestApi/Suppression.cs
+++ b/MailerQ/RestApi/Suppression.cs
@@ -1,0 +1,55 @@
+﻿using Newtonsoft.Json;
+
+namespace MailerQ.RestApi
+{
+    /// <summary>
+    /// Suppression Types
+    /// </summary>
+    public enum SuppressionTypes
+    {
+        /// <summary>
+        /// Suppress a full address
+        /// </summary>
+        Address,
+        /// <summary>
+        /// Suppress a domain
+        /// </summary>
+        Domain
+    }
+
+    /// <summary>
+    /// Suppression is functionality to prevent unwanted recipients from being tried and protect reputation.
+    /// </summary>
+    [JsonObject(
+        NamingStrategyType = typeof(LowercaseNamingStrategy),
+        ItemNullValueHandling = NullValueHandling.Ignore
+    )]
+    public class Suppression
+    {
+        /// <summary>
+        /// The domain or address to be suppressed
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public string Value { get; set; }
+
+        /// <summary>
+        /// ("address", "domain")	Whether the given value is a domain or a full address
+        /// </summary>
+        public SuppressionTypes Type { get; set; }
+
+        /// <summary>
+        /// The error code given to suppressed messages.
+        /// </summary>
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Extended SMTP error code, e.g. 5.7.1.
+        /// </summary>
+        public string Extended { get; set; }
+
+        /// <summary>
+        /// Description to put in the message result.
+        /// </summary>
+        public string Description { get; set; }
+    }
+}


### PR DESCRIPTION
This PR add types for interact with the endpoints added in MailerQ 5.8

- [Pools](https://www.mailerq.com/documentation/5.8/rest-api-v1-pools)
- [Suppressions](https://www.mailerq.com/documentation/5.8/rest-api-v1-suppressions)
- [External MTAs]( https://www.mailerq.com/documentation/5.8/rest-api-v1-externalmtas)