### PR TITLE
Update RabbitMQ.Cliente to v6.2.1

### DIFF
--- a/MailerQ/MailerQ.csproj
+++ b/MailerQ/MailerQ.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EasyNetQ" Version="5.1.2" />
+    <PackageReference Include="EasyNetQ" Version="5.2.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.11.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.7" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/MailerQ/MailerQ.csproj
+++ b/MailerQ/MailerQ.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="MongoDB.Driver" Version="2.11.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.7" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The RabbitMQ.Client is a dependency of EasyNetQ this change force to use the last version.