### PR TITLE
[DM-626] add RabbitPassword configuration

### DIFF
--- a/MailerQ/Core/MailerQConfiguration.cs
+++ b/MailerQ/Core/MailerQConfiguration.cs
@@ -4,6 +4,12 @@
     {
         public string RabbitConnectionString { get; set; }
 
+        /// <summary>
+        /// Password for connect to RabbitMQ. 
+        /// If RabbitConnectionString has defined password parameter, will be replaced with this value if it is not empty.
+        /// </summary>
+        public string RabbitPassword { get; set; }
+
         public string QueuesNamePrefix { get; set; }
 
         public string MessageStorageUrl { get; set; }

--- a/MailerQ/Core/QueueManager.cs
+++ b/MailerQ/Core/QueueManager.cs
@@ -1,4 +1,5 @@
 ﻿using EasyNetQ;
+using EasyNetQ.ConnectionString;
 using EasyNetQ.Topology;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
@@ -16,6 +17,12 @@ namespace MailerQ
         public QueueManager(MailerQConfiguration configuration)
         {
             this.configuration = configuration;
+            var connectionString = new ConnectionStringParser().Parse(configuration.RabbitConnectionString);
+            if (string.IsNullOrWhiteSpace(configuration.RabbitPassword))
+            {
+                connectionString.Password = configuration.RabbitPassword;
+            }
+
             bus = RabbitHutch.CreateBus(configuration.RabbitConnectionString).Advanced;
         }
 


### PR DESCRIPTION
This will allow store the password for connect to rabbit as a separate value of the connection string.
This is useful to encrypt this value as a secret and hold the connection string as a clear value

Related to: [DM-626](https://makingsense.atlassian.net/browse/DM-626)