### PR TITLE
Improve rabbitmqclientpublisher

### DIFF
--- a/MailerQ/Core/RabbitMQClientPublisher.cs
+++ b/MailerQ/Core/RabbitMQClientPublisher.cs
@@ -85,7 +85,15 @@ namespace MailerQ
         {
             if (_settings.PublisherConfirms)
             {
-                _channel.WaitForConfirmsOrDie(new TimeSpan(0, 0, _settings.Timeout));
+                var confirmed = _channel.WaitForConfirms(new TimeSpan(0, 0, _settings.Timeout), out var timedout);
+                if (timedout)
+                {
+                    throw new TimeoutException("No Ack or Nack recived before timeout");
+                }
+                if (!confirmed)
+                {
+                    throw new Exception("Message publish was explicitly Nacked");
+                }
             }
         }
 

--- a/MailerQ/Core/RabbitMQClientPublisher.cs
+++ b/MailerQ/Core/RabbitMQClientPublisher.cs
@@ -52,8 +52,6 @@ namespace MailerQ
 
         public void Publish(OutgoingMessage outgoingMessage, string queueName = QueueName.Outbox)
         {
-            _channel.QueueDeclarePassive(queueName);
-
             var properties = _channel.CreateBasicProperties();
             properties.Persistent = _settings.PersistentMessages;
             properties.Priority = (byte)outgoingMessage.Priority;
@@ -70,8 +68,6 @@ namespace MailerQ
 
         public void Publish(IEnumerable<OutgoingMessage> outgoingMessages, string queueName = QueueName.Outbox)
         {
-            _channel.QueueDeclarePassive(queueName);
-
             var batch = _channel.CreateBasicPublishBatch();
 
             foreach (var outgoingMessage in outgoingMessages)

--- a/MailerQ/Core/RabbitMQClientPublisher.cs
+++ b/MailerQ/Core/RabbitMQClientPublisher.cs
@@ -59,11 +59,7 @@ namespace MailerQ
             var body = CreateBody(outgoingMessage);
 
             _channel.BasicPublish(exchange: "", routingKey: queueName, mandatory: false, properties, body);
-
-            if (_settings.PublisherConfirms)
-            {
-                _channel.WaitForConfirmsOrDie(new TimeSpan(0, 0, _settings.Timeout));
-            }
+            WaitConfirmation();
         }
 
         public void Publish(IEnumerable<OutgoingMessage> outgoingMessages, string queueName = QueueName.Outbox)
@@ -82,7 +78,11 @@ namespace MailerQ
             }
 
             batch.Publish();
+            WaitConfirmation();
+        }
 
+        private void WaitConfirmation()
+        {
             if (_settings.PublisherConfirms)
             {
                 _channel.WaitForConfirmsOrDie(new TimeSpan(0, 0, _settings.Timeout));


### PR DESCRIPTION
Not declare queue, is expect that already exist declared by _MailerQ_
When the messages are not confirme now will throw an exception.