### PR TITLE
Declare deadletter queue for publish outgoingmessages

### DIFF
--- a/MailerQ/Core/IQueueDeclarer.cs
+++ b/MailerQ/Core/IQueueDeclarer.cs
@@ -1,0 +1,29 @@
+﻿using MailerQ.Conventions;
+
+namespace MailerQ
+{
+    /// <summary>
+    /// Interfaz to declare queues
+    /// </summary>
+    public interface IQueueDeclarer
+    {
+        /// <summary>
+        /// Declare a deadletter queue for publish OutgoingMessages
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="addQueueNamePrefix">Add prefix to queue name</param>
+        /// <param name="durable"></param>
+        /// <param name="messageTtl"></param>
+        /// <param name="maxPriority"></param>
+        /// <param name="deadLetterExchange"></param>
+        /// <param name="deadLetterRoutingKey"></param>
+        void DeclareDeadLetterQueueForPublish(
+            string name,
+            bool addQueueNamePrefix = true,
+            bool durable = true,
+            int messageTtl = 10,
+            int maxPriority = (int)Priority.High,
+            string deadLetterExchange = "",
+            string deadLetterRoutingKey = QueueName.Outbox);
+    }
+}


### PR DESCRIPTION
This PR is for include a method to declare queues using as default a convention to generate queue that route `OutgoingMessage` to the conventional _outbox_ queue declared as default for _MailerQ_

The value are configurable to set different of ttl, or the queue or exchange to route de message

Related to: [DM-727](https://makingsense.atlassian.net/browse/DM-727)