### PR TITLE
[DD-555] add mailerq rest api client

### DIFF
--- a/MailerQ.Test/MailerQ.Test.csproj
+++ b/MailerQ.Test/MailerQ.Test.csproj
@@ -7,7 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="3.0.3" />

--- a/MailerQ.Test/RestApiClientTest.cs
+++ b/MailerQ.Test/RestApiClientTest.cs
@@ -257,5 +257,34 @@ namespace MailerQ.RestApi.Test
             // Assert
             Assert.NotNull(result.Content);
         }
+
+        [Fact]
+        public async Task Get_PoolIP_should_add_query_string_parameter_of_the_pool_name()
+        {
+            // Arrange
+            var httpResponseMessage = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+            };
+            var httpMessageHandlerMock = CreateHttpMessageHandlerMock(httpResponseMessage);
+            var httpClientFactoryMock = CreateHttpClientFactoryMock(httpMessageHandlerMock.Object);
+            var sut = CreateSut(httpClientFactory: httpClientFactoryMock.Object);
+
+            var pool = specimens.Create<Pool>();
+            var poolIPGetRequest = new PoolIPGetRequest(pool.Name);
+
+            var expectedQueryString = $"name={pool.Name}";
+
+            // Act
+            var result = await sut.GetAsync(poolIPGetRequest);
+
+            // Assert
+            httpMessageHandlerMock.Protected().Verify(
+               nameof(HttpClient.SendAsync),
+               Times.Exactly(1),
+               ItExpr.Is<HttpRequestMessage>(request => request.RequestUri.Query.Contains(expectedQueryString)),
+               ItExpr.IsAny<CancellationToken>()
+            );
+        }
     }
 }

--- a/MailerQ.Test/RestApiClientTest.cs
+++ b/MailerQ.Test/RestApiClientTest.cs
@@ -1,0 +1,261 @@
+﻿using AutoFixture;
+using Microsoft.Extensions.Options;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MailerQ.RestApi.Test
+{
+    public class RestApiClientTest
+    {
+        private const string Version = "v1";
+        private static readonly Fixture specimens = new();
+
+        private static IRestApiClient CreateSut(
+            MailerQConfiguration mailerQConfiguration = null,
+            IHttpClientFactory httpClientFactory = null
+            )
+        {
+            mailerQConfiguration ??= new MailerQConfiguration { RestApiUrl = $"http://localhost/{Version}/", RestApiToken = specimens.Create<string>() };
+
+            return new RestApiClient(
+                options: Options.Create(mailerQConfiguration),
+                httpFactory: httpClientFactory ?? Mock.Of<IHttpClientFactory>()
+                );
+        }
+
+        private static Mock<HttpMessageHandler> CreateHttpMessageHandlerMock(HttpResponseMessage httpResponseMessage)
+        {
+            var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+            httpMessageHandlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>(nameof(HttpClient.SendAsync), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(httpResponseMessage);
+
+            return httpMessageHandlerMock;
+        }
+
+        private static Mock<HttpMessageHandler> CreateHttpMessageHandlerMock(Exception exception)
+        {
+            var httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+            httpMessageHandlerMock.Protected()
+                .Setup<Task<HttpResponseMessage>>(nameof(HttpClient.SendAsync), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+                .ThrowsAsync(exception);
+
+            return httpMessageHandlerMock;
+        }
+
+        private static Mock<IHttpClientFactory> CreateHttpClientFactoryMock(HttpMessageHandler httpMessageHandler)
+        {
+            var httpClient = new HttpClient(httpMessageHandler);
+
+            var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+            httpClientFactoryMock
+                .Setup(_ => _.CreateClient(It.IsAny<string>()))
+                .Returns(httpClient);
+
+            return httpClientFactoryMock;
+        }
+
+        public static IEnumerable<object[]> RestApiModelSpecimens()
+        {
+            yield return new object[] { specimens.Create<Inject>() };
+            yield return new object[] { specimens.Create<Pause>() };
+            yield return new object[] { specimens.Create<Error>() };
+            yield return new object[] { specimens.Create<Pool>() };
+            yield return new object[] { specimens.Create<IpPool>() };
+            yield return new object[] { specimens.Create<PoolIP>() };
+            yield return new object[] { specimens.Create<IpAddress>() };
+            yield return new object[] { specimens.Create<Suppression>() };
+            yield return new object[] { specimens.Create<ExternalMTA>() };
+            yield return new object[] { specimens.Create<ExternalIp>() };
+        }
+
+        public static IEnumerable<object[]> RestApiModelEndpointSpecimens()
+        {
+            yield return new object[] { specimens.Create<Inject>(), $"{Version}/inject" };
+            yield return new object[] { specimens.Create<Pause>(), $"{Version}/pauses" };
+            yield return new object[] { specimens.Create<Error>(), $"{Version}/errors" };
+            yield return new object[] { specimens.Create<Pool>(), $"{Version}/pools" };
+            yield return new object[] { specimens.Create<IpPool>(), $"{Version}/pools" };
+            yield return new object[] { specimens.Create<PoolIP>(), $"{Version}/poolips" };
+            yield return new object[] { specimens.Create<IpAddress>(), $"{Version}/poolips" };
+            yield return new object[] { specimens.Create<Suppression>(), $"{Version}/suppressions" };
+            yield return new object[] { specimens.Create<ExternalMTA>(), $"{Version}/externalmtas" };
+            yield return new object[] { specimens.Create<ExternalIp>(), $"{Version}/externalmtas" };
+        }
+
+        [Theory]
+        [MemberData(nameof(RestApiModelEndpointSpecimens))]
+        public async Task Should_request_to_the_expected_endpoint_name_for_model_type<T>(T model, string endpoint) where T : IRestApiModel
+        {
+            // Arrange
+            var httpResponseMessage = new HttpResponseMessage
+            {
+                StatusCode = specimens.Create<HttpStatusCode>(),
+            };
+
+            var httpMessageHandlerMock = CreateHttpMessageHandlerMock(httpResponseMessage);
+            var httpClientFactoryMock = CreateHttpClientFactoryMock(httpMessageHandlerMock.Object);
+            var sut = CreateSut(httpClientFactory: httpClientFactoryMock.Object);
+
+            // Act
+            await sut.GetAsync<T>();
+            await sut.PostAsync(model);
+            await sut.DeleteAsync(model);
+
+            // Assert
+            httpMessageHandlerMock.Protected().Verify(
+               nameof(HttpClient.SendAsync),
+               Times.Exactly(3),
+               ItExpr.Is<HttpRequestMessage>(request => request.RequestUri.AbsolutePath.EndsWith(endpoint)),
+               ItExpr.IsAny<CancellationToken>()
+            );
+        }
+
+        [Theory]
+        [MemberData(nameof(RestApiModelSpecimens))]
+        public async Task Get_should_return_http_status_code_on_sucessfull<T>(T model) where T : IRestApiModel
+        {
+            // Arrange
+            var httpResponseMessage = new HttpResponseMessage
+            {
+                StatusCode = specimens.Create<HttpStatusCode>(),
+            };
+
+            var httpMessageHandlerMock = CreateHttpMessageHandlerMock(httpResponseMessage);
+            var httpClientFactoryMock = CreateHttpClientFactoryMock(httpMessageHandlerMock.Object);
+            var sut = CreateSut(httpClientFactory: httpClientFactoryMock.Object);
+
+            // Act
+            var result = await sut.GetAsync<T>();
+
+            // Assert
+            Assert.Equal(httpResponseMessage.StatusCode, result.HttpStatusCode);
+        }
+
+        [Theory]
+        [MemberData(nameof(RestApiModelSpecimens))]
+        public async Task Post_should_return_http_status_code_on_sucessfull(IRestApiModel model)
+        {
+            // Arrange
+            var httpResponseMessage = new HttpResponseMessage
+            {
+                StatusCode = specimens.Create<HttpStatusCode>(),
+            };
+
+            var httpMessageHandlerMock = CreateHttpMessageHandlerMock(httpResponseMessage);
+            var httpClientFactoryMock = CreateHttpClientFactoryMock(httpMessageHandlerMock.Object);
+            var sut = CreateSut(httpClientFactory: httpClientFactoryMock.Object);
+
+            // Act
+            var result = await sut.PostAsync(model);
+
+            // Assert
+            Assert.Equal(httpResponseMessage.StatusCode, result.HttpStatusCode);
+        }
+
+        [Theory]
+        [MemberData(nameof(RestApiModelSpecimens))]
+        public async Task Delete_should_return_http_status_code_on_sucessfull(IRestApiModel model)
+        {
+            // Arrange
+            var httpResponseMessage = new HttpResponseMessage
+            {
+                StatusCode = specimens.Create<HttpStatusCode>(),
+            };
+
+            var httpMessageHandlerMock = CreateHttpMessageHandlerMock(httpResponseMessage);
+            var httpClientFactoryMock = CreateHttpClientFactoryMock(httpMessageHandlerMock.Object);
+            var sut = CreateSut(httpClientFactory: httpClientFactoryMock.Object);
+
+            // Act
+            var result = await sut.DeleteAsync(model);
+
+            // Assert
+            Assert.Equal(httpResponseMessage.StatusCode, result.HttpStatusCode);
+        }
+
+        [Theory]
+        [MemberData(nameof(RestApiModelSpecimens))]
+        public async Task Get_should_throw_RestApiException_upon_an_exception_in_the_implementation<T>(T model) where T : IRestApiModel
+        {
+            // Arrange
+            var exception = specimens.Create<Exception>();
+
+            var httpMessageHandlerMock = CreateHttpMessageHandlerMock(exception);
+            var httpClientFactoryMock = CreateHttpClientFactoryMock(httpMessageHandlerMock.Object);
+            var sut = CreateSut(httpClientFactory: httpClientFactoryMock.Object);
+
+            // Act
+            var result = await Assert.ThrowsAsync<RestApiException>(() => sut.GetAsync<T>());
+
+            // Assert
+            Assert.Equal(exception, result.InnerException);
+        }
+
+        [Theory]
+        [MemberData(nameof(RestApiModelSpecimens))]
+        public async Task Post_should_throw_RestApiException_upon_an_exception_in_the_implementation(IRestApiModel model)
+        {
+            // Arrange
+            var exception = specimens.Create<Exception>();
+
+            var httpMessageHandlerMock = CreateHttpMessageHandlerMock(exception);
+            var httpClientFactoryMock = CreateHttpClientFactoryMock(httpMessageHandlerMock.Object);
+            var sut = CreateSut(httpClientFactory: httpClientFactoryMock.Object);
+
+            // Act
+            var result = await Assert.ThrowsAsync<RestApiException>(() => sut.PostAsync(model));
+
+            // Assert
+            Assert.Equal(exception, result.InnerException);
+        }
+
+        [Theory]
+        [MemberData(nameof(RestApiModelSpecimens))]
+        public async Task Delete_should_throw_RestApiException_upon_an_exception_in_the_implementation(IRestApiModel model)
+        {
+            // Arrange
+            var exception = specimens.Create<Exception>();
+
+            var httpMessageHandlerMock = CreateHttpMessageHandlerMock(exception);
+            var httpClientFactoryMock = CreateHttpClientFactoryMock(httpMessageHandlerMock.Object);
+            var sut = CreateSut(httpClientFactory: httpClientFactoryMock.Object);
+
+            // Act
+            var result = await Assert.ThrowsAsync<RestApiException>(() => sut.DeleteAsync(model));
+
+            // Assert
+            Assert.Equal(exception, result.InnerException);
+        }
+
+        [Theory]
+        [MemberData(nameof(RestApiModelSpecimens))]
+        public async Task Get_should_return_the_object_model_collection_on_sucessfull<T>(T model) where T : IRestApiModel
+        {
+            // Arrange
+            var jsonListWithModel = JsonConvert.SerializeObject(new List<T> { model });
+            var httpResponseMessage = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(jsonListWithModel)
+            };
+            var httpMessageHandlerMock = CreateHttpMessageHandlerMock(httpResponseMessage);
+            var httpClientFactoryMock = CreateHttpClientFactoryMock(httpMessageHandlerMock.Object);
+            var sut = CreateSut(httpClientFactory: httpClientFactoryMock.Object);
+
+            // Act
+            var result = await sut.GetAsync<T>();
+
+            // Assert
+            Assert.NotNull(result.Content);
+        }
+    }
+}

--- a/MailerQ/MailerQ.csproj
+++ b/MailerQ/MailerQ.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="MongoDB.Driver" Version="2.12.4" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.3" />
   </ItemGroup>
 
 </Project>

--- a/MailerQ/RestApi/Error.cs
+++ b/MailerQ/RestApi/Error.cs
@@ -9,7 +9,7 @@ namespace MailerQ.RestApi
         NamingStrategyType = typeof(LowercaseNamingStrategy),
         ItemNullValueHandling = NullValueHandling.Ignore
     )]
-    public class Error
+    public class Error : IRestApiModel
     {
         /// <summary>
         /// Numeric error code between 200 and 599 (smtp error codes).

--- a/MailerQ/RestApi/ExternalMTA.cs
+++ b/MailerQ/RestApi/ExternalMTA.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System;
 
 namespace MailerQ.RestApi
 {
@@ -29,30 +30,45 @@ namespace MailerQ.RestApi
         NamingStrategyType = typeof(LowercaseNamingStrategy),
         ItemNullValueHandling = NullValueHandling.Ignore
     )]
-    public class ExternalIP
+    [Obsolete("User ExternalMTA class")]
+    public class ExternalIp : ExternalMTA { }
+
+    /// <summary>
+    /// External MTA.
+    /// Setting to uses IP address that is not local to the server MailerQ is running on.
+    /// </summary>
+    [JsonObject(
+        NamingStrategyType = typeof(LowercaseNamingStrategy),
+        ItemNullValueHandling = NullValueHandling.Ignore
+    )]
+    public class ExternalMTA : IRestApiModel
     {
         /// <summary>
         /// The external IP address to use for sending
         /// </summary>
         [JsonProperty("public_ip", Required = Required.Always)]
         public string PublicIP { get; set; }
+
         /// <summary>
         /// The local IP address to bind to
         /// </summary>
         [JsonProperty("local_ip")]
         public string LocalIP { get; set; }
+
         /// <summary>
         /// The IP to use for the external server
         /// </summary>
         [JsonProperty("connect_ip")]
         public string ConnectIP { get; set; }
+
         /// <summary>
         /// The port to use for the external server
         /// </summary>
         [JsonProperty("connect_port")]
         public int ConnectPort { get; set; }
+
         /// <summary>
-        /// The protocol to use to connect to the external server(currently only 'nat' is supported)
+        /// The protocol to use to connect to the external server
         /// </summary>
         [JsonProperty(Required = Required.Always)]
         public ExternalIpProtocol Protocol { get; set; }

--- a/MailerQ/RestApi/ExternalMTA.cs
+++ b/MailerQ/RestApi/ExternalMTA.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using System;
 
 namespace MailerQ.RestApi
@@ -71,6 +72,7 @@ namespace MailerQ.RestApi
         /// The protocol to use to connect to the external server
         /// </summary>
         [JsonProperty(Required = Required.Always)]
+        [JsonConverter(typeof(StringEnumConverter))]
         public ExternalIpProtocol Protocol { get; set; }
     }
 }

--- a/MailerQ/RestApi/IRestApiClient.cs
+++ b/MailerQ/RestApi/IRestApiClient.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace MailerQ.RestApi
+{
+    /// <summary>
+    /// Contract that represent the HTTP methods availables in the MailerQ Rest API
+    /// </summary>
+    public interface IRestApiClient
+    {
+        /// <summary>
+        /// Request an HTTP Get to obtain a collection of instances of the model
+        /// </summary>
+        /// <typeparam name="T">Model type that return the endpoint</typeparam>
+        /// <param name="restApiRequest">Specific definition of request the Rest API</param>
+        /// <param name="cancellationToken">The request cancellationToken</param>
+        /// <returns>Response information returned on the request including the collection of instances of the model</returns>
+        Task<IRestApiResponse<T>> Get<T>(
+            IRestApiRequest<T> restApiRequest = default,
+            CancellationToken cancellationToken = default) where T : IRestApiModel;
+
+        /// <summary>
+        /// Request an HTTP Post create or update an instance of the model
+        /// </summary>
+        /// <typeparam name="T">Model type that accept the endpoint</typeparam>
+        /// <param name="model">Object model to send in the request body</param>
+        /// <param name="cancellationToken">The request cancellationToken</param>
+        /// <returns>Response information returned on the request</returns>
+        Task<IRestApiResponse<T>> Post<T>(T model, CancellationToken cancellationToken = default) where T : IRestApiModel;
+
+        /// <summary>
+        /// Request an HTTP Delete remove an instance of the model
+        /// </summary>
+        /// <typeparam name="T">Model type that accept the endpoint</typeparam>
+        /// <param name="model">Object model to send in the request body</param>
+        /// <param name="cancellationToken">The request cancellationToken</param>
+        /// <returns>Response information returned on the request</returns>
+        Task<IRestApiResponse<T>> Delete<T>(T model, CancellationToken cancellationToken = default) where T : IRestApiModel;
+    }
+}

--- a/MailerQ/RestApi/IRestApiClient.cs
+++ b/MailerQ/RestApi/IRestApiClient.cs
@@ -15,7 +15,7 @@ namespace MailerQ.RestApi
         /// <param name="restApiRequest">Specific definition of request the Rest API</param>
         /// <param name="cancellationToken">The request cancellationToken</param>
         /// <returns>Response information returned on the request including the collection of instances of the model</returns>
-        Task<IRestApiResponse<T>> Get<T>(
+        Task<IRestApiResponse<T>> GetAsync<T>(
             IRestApiRequest<T> restApiRequest = default,
             CancellationToken cancellationToken = default) where T : IRestApiModel;
 
@@ -26,7 +26,7 @@ namespace MailerQ.RestApi
         /// <param name="model">Object model to send in the request body</param>
         /// <param name="cancellationToken">The request cancellationToken</param>
         /// <returns>Response information returned on the request</returns>
-        Task<IRestApiResponse<T>> Post<T>(T model, CancellationToken cancellationToken = default) where T : IRestApiModel;
+        Task<IRestApiResponse<T>> PostAsync<T>(T model, CancellationToken cancellationToken = default) where T : IRestApiModel;
 
         /// <summary>
         /// Request an HTTP Delete remove an instance of the model
@@ -35,6 +35,6 @@ namespace MailerQ.RestApi
         /// <param name="model">Object model to send in the request body</param>
         /// <param name="cancellationToken">The request cancellationToken</param>
         /// <returns>Response information returned on the request</returns>
-        Task<IRestApiResponse<T>> Delete<T>(T model, CancellationToken cancellationToken = default) where T : IRestApiModel;
+        Task<IRestApiResponse<T>> DeleteAsync<T>(T model, CancellationToken cancellationToken = default) where T : IRestApiModel;
     }
 }

--- a/MailerQ/RestApi/IRestApiModel.cs
+++ b/MailerQ/RestApi/IRestApiModel.cs
@@ -1,0 +1,9 @@
+﻿namespace MailerQ.RestApi
+{
+    /// <summary>
+    /// Contract to identify classes that represent an object model used in the MailerQ Rest API
+    /// </summary>
+    public interface IRestApiModel
+    {
+    }
+}

--- a/MailerQ/RestApi/IRestApiRequest.cs
+++ b/MailerQ/RestApi/IRestApiRequest.cs
@@ -1,0 +1,14 @@
+﻿namespace MailerQ.RestApi
+{
+    /// <summary>
+    /// Contract that represent a basic MailerQ Rest API request
+    /// </summary>
+    /// <typeparam name="T">Model type that accept the endpoint</typeparam>
+    public interface IRestApiRequest<T> where T : IRestApiModel
+    {
+        /// <summary>
+        /// The query string parameters
+        /// </summary>
+        string QueryString { get; }
+    }
+}

--- a/MailerQ/RestApi/IRestApiResponse.cs
+++ b/MailerQ/RestApi/IRestApiResponse.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using System.Net;
+
+namespace MailerQ.RestApi
+{
+    /// <summary>
+    /// Contract that represent a MailerQ Rest API response
+    /// </summary>
+    /// <typeparam name="T">Model type that return the endpoint</typeparam>
+    public interface IRestApiResponse<T> where T : IRestApiModel
+    {
+        /// <summary>
+        /// Response HTTP status code
+        /// </summary>
+        HttpStatusCode HttpStatusCode { get; }
+
+        /// <summary>
+        /// Collection of object deserialized from the response content
+        /// </summary>
+        ICollection<T> Content { get; }
+    }
+}

--- a/MailerQ/RestApi/Inject.cs
+++ b/MailerQ/RestApi/Inject.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+
+namespace MailerQ.RestApi
+{
+    [JsonObject(
+        NamingStrategyType = typeof(LowercaseNamingStrategy),
+        ItemNullValueHandling = NullValueHandling.Ignore
+    )]
+    public class Inject : OutgoingMessage, IRestApiModel
+    {
+    }
+}

--- a/MailerQ/RestApi/Inject.cs
+++ b/MailerQ/RestApi/Inject.cs
@@ -2,6 +2,9 @@
 
 namespace MailerQ.RestApi
 {
+    /// <summary>
+    /// Represent a model of OutgoingMessage to inject in the MailerQ Rest API
+    /// </summary>
     [JsonObject(
         NamingStrategyType = typeof(LowercaseNamingStrategy),
         ItemNullValueHandling = NullValueHandling.Ignore

--- a/MailerQ/RestApi/Pause.cs
+++ b/MailerQ/RestApi/Pause.cs
@@ -9,7 +9,7 @@ namespace MailerQ.RestApi
         NamingStrategyType = typeof(LowercaseNamingStrategy),
         ItemNullValueHandling = NullValueHandling.Ignore
     )]
-    public class Pause
+    public class Pause : IRestApiModel
     {
         /// <summary>
         /// Pool that the pause applies to.

--- a/MailerQ/RestApi/Pool.cs
+++ b/MailerQ/RestApi/Pool.cs
@@ -1,0 +1,38 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace MailerQ.RestApi
+{
+    /// <summary>
+    /// Pool of IPs
+    /// MailerQ offers IP Pools for easy management of your sending IP addresses.
+    /// </summary>
+    [JsonObject(
+        NamingStrategyType = typeof(LowercaseNamingStrategy),
+        ItemNullValueHandling = NullValueHandling.Ignore
+    )]
+    public class Pool : IRestApiModel
+    {
+        /// <summary>
+        /// The name of the pool
+        /// </summary>
+        [JsonProperty(Required = Required.Always)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Description of the pool, for human use.
+        /// </summary>
+        public string Description { get; set; }
+    }
+
+    /// <summary>
+    /// Pool of IPs
+    /// MailerQ offers IP Pools for easy management of your sending IP addresses.
+    /// </summary>
+    [JsonObject(
+        NamingStrategyType = typeof(LowercaseNamingStrategy),
+        ItemNullValueHandling = NullValueHandling.Ignore
+    )]
+    [Obsolete("User Pool class")]
+    public class IpPool : Pool { }
+}

--- a/MailerQ/RestApi/PoolIP.cs
+++ b/MailerQ/RestApi/PoolIP.cs
@@ -4,7 +4,7 @@ using System;
 namespace MailerQ.RestApi
 {
     /// <summary>
-    /// IP Address
+    /// An Internet Protocol Address of one Pool
     /// MailerQ offers IP Pools for easy management of your sending IP addresses.
     /// </summary>
     /// <remarks>Get method requiere indicate the pool name as request parameter</remarks>
@@ -26,10 +26,7 @@ namespace MailerQ.RestApi
         public string Name { get; set; }
     }
 
-    /// <summary>
-    /// IP Address
-    /// MailerQ offers IP Pools for easy management of your sending IP addresses.
-    /// </summary>
+    /// <inheritdoc />
     [JsonObject(
         NamingStrategyType = typeof(LowercaseNamingStrategy),
         ItemNullValueHandling = NullValueHandling.Ignore

--- a/MailerQ/RestApi/PoolIP.cs
+++ b/MailerQ/RestApi/PoolIP.cs
@@ -18,7 +18,7 @@ namespace MailerQ.RestApi
         /// The IP address
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public string Ip { get; set; }
+        public string LocalIp { get; set; }
         /// <summary>
         /// The name of the pool
         /// </summary>

--- a/MailerQ/RestApi/PoolIP.cs
+++ b/MailerQ/RestApi/PoolIP.cs
@@ -1,38 +1,18 @@
 ﻿using Newtonsoft.Json;
+using System;
 
 namespace MailerQ.RestApi
 {
     /// <summary>
-    /// Pool of IPs
-    /// MailerQ offers IP Pools for easy management of your sending IP addresses.
-    /// </summary>
-    [JsonObject(
-        NamingStrategyType = typeof(LowercaseNamingStrategy),
-        ItemNullValueHandling = NullValueHandling.Ignore
-    )]
-    public class IpPool
-    {
-        /// <summary>
-        /// The name of the pool
-        /// </summary>
-        [JsonProperty(Required = Required.Always)]
-        public string Name { get; set; }
-
-        /// <summary>
-        /// Description of the pool, for human use.
-        /// </summary>
-        public string Description { get; set; }
-    }
-
-    /// <summary>
     /// IP Address
     /// MailerQ offers IP Pools for easy management of your sending IP addresses.
     /// </summary>
+    /// <remarks>Get method requiere indicate the pool name as request parameter</remarks>
     [JsonObject(
         NamingStrategyType = typeof(LowercaseNamingStrategy),
         ItemNullValueHandling = NullValueHandling.Ignore
     )]
-    public class IpAddress
+    public class PoolIP : IRestApiModel
     {
         /// <summary>
         /// The IP address
@@ -44,6 +24,16 @@ namespace MailerQ.RestApi
         /// </summary>
         [JsonProperty(Required = Required.Always)]
         public string Name { get; set; }
-
     }
+
+    /// <summary>
+    /// IP Address
+    /// MailerQ offers IP Pools for easy management of your sending IP addresses.
+    /// </summary>
+    [JsonObject(
+        NamingStrategyType = typeof(LowercaseNamingStrategy),
+        ItemNullValueHandling = NullValueHandling.Ignore
+    )]
+    [Obsolete("User PoolIP class")]
+    public class IpAddress : PoolIP { }
 }

--- a/MailerQ/RestApi/PoolIPGetRequest.cs
+++ b/MailerQ/RestApi/PoolIPGetRequest.cs
@@ -1,0 +1,22 @@
+﻿namespace MailerQ.RestApi
+{
+    /// <summary>
+    /// A rest API GET request specific for PoolIP endpoint
+    /// </summary>
+    public class PoolIPGetRequest : IRestApiRequest<PoolIP>
+    {
+        private readonly string poolName;
+
+        /// <summary>
+        /// Initializes a new instance of GET request specific for PoolIP endpoint
+        /// </summary>
+        /// <param name="poolName">The Pool name of IPs</param>
+        public PoolIPGetRequest(string poolName)
+        {
+            this.poolName = poolName;
+        }
+
+        /// <inheritdoc />
+        public string QueryString => $"name={poolName}";
+    }
+}

--- a/MailerQ/RestApi/RestApiClient.cs
+++ b/MailerQ/RestApi/RestApiClient.cs
@@ -1,0 +1,141 @@
+﻿using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MailerQ.RestApi
+{
+    /// <summary>
+    /// A client of MailerQ Rest API implement with HttpClient
+    /// </summary>
+    public class RestApiClient : IRestApiClient
+    {
+        private readonly MailerQConfiguration _settings;
+        private readonly IHttpClientFactory _httpFactory;
+
+        /// <summary>
+        /// Initializes a new instance of MailerQ Rest API Client
+        /// </summary>
+        /// <param name="options">MailerQ settings with API Url and Authorization Token</param>
+        /// <param name="httpFactory">HttpClienFactory for create HttpClient objects</param>
+        public RestApiClient(
+            IOptions<MailerQConfiguration> options,
+            IHttpClientFactory httpFactory)
+        {
+            _settings = options.Value;
+            _httpFactory = httpFactory;
+        }
+
+        private HttpClient CreateHttpClient()
+        {
+            var client = _httpFactory.CreateClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _settings.RestApiToken);
+            return client;
+        }
+
+        private string GetEndPoint(Type type)
+        {
+            var typeName = type.Name;
+
+            // HACK: this allow get the correct endpoint for obsolete classes that inhiret from the classes with expected name
+            if (type.BaseType != null && typeof(IRestApiModel).IsAssignableFrom(type.BaseType))
+            {
+                typeName = type.BaseType.Name;
+            }
+
+            var endpointName = $"{typeName.ToLowerInvariant()}s";
+
+            if (type == typeof(Inject))
+            {
+                endpointName = "inject";
+            }
+
+            var baseUri = new Uri(_settings.RestApiUrl);
+            var endpointUri = new Uri(baseUri, endpointName);
+            return endpointUri.ToString();
+        }
+
+        /// <inheritdoc />
+        public async Task<IRestApiResponse<T>> GetAsync<T>(
+            IRestApiRequest<T> restApiRequest = default,
+            CancellationToken cancellationToken = default) where T : IRestApiModel
+        {
+            try
+            {
+                var endpoint = GetEndPoint(typeof(T));
+                if (!string.IsNullOrWhiteSpace(restApiRequest?.QueryString))
+                {
+                    endpoint += $"?{restApiRequest.QueryString}";
+                }
+
+                var client = CreateHttpClient();
+                var httpResponse = await client.GetAsync(endpoint, cancellationToken);
+                if (httpResponse.StatusCode == HttpStatusCode.OK)
+                {
+                    var result = await httpResponse.Content.ReadAsStringAsync();
+                    var content = JsonConvert.DeserializeObject<List<T>>(result);
+                    return new RestApiResponse<T>(httpResponse.StatusCode, content);
+                }
+
+                return new RestApiResponse<T>(httpResponse.StatusCode);
+            }
+            catch (Exception exception)
+            {
+                throw new RestApiException("Unexpected exception", exception);
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<IRestApiResponse<T>> DeleteAsync<T>(T model, CancellationToken cancellationToken = default) where T : IRestApiModel
+        {
+            try
+            {
+                var endpoint = GetEndPoint(model.GetType());
+                var jsonContent = JsonConvert.SerializeObject(model);
+
+                var client = CreateHttpClient();
+                HttpContent httpContent = new StringContent(jsonContent);
+                httpContent.Headers.ContentType.MediaType = "application/json";
+
+                var httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, endpoint)
+                {
+                    Content = httpContent
+                };
+
+                var httpResponse = await client.SendAsync(httpRequestMessage, cancellationToken);
+
+                return new RestApiResponse<T>(httpResponse.StatusCode);
+            }
+            catch (Exception exception)
+            {
+                throw new RestApiException("Unexpected exception", exception);
+            }
+        }
+
+        /// <inheritdoc />
+        public async Task<IRestApiResponse<T>> PostAsync<T>(T model, CancellationToken cancellationToken = default) where T : IRestApiModel
+        {
+            try
+            {
+                var endpoint = GetEndPoint(model.GetType());
+                var jsonContent = JsonConvert.SerializeObject(model);
+
+                var client = CreateHttpClient();
+                HttpContent httpContent = new StringContent(jsonContent);
+                httpContent.Headers.ContentType.MediaType = "application/json";
+                var httpResponse = await client.PostAsync(endpoint, httpContent, cancellationToken);
+
+                return new RestApiResponse<T>(httpResponse.StatusCode);
+            }
+            catch (Exception exception)
+            {
+                throw new RestApiException("Unexpected exception", exception);
+            }
+        }
+    }
+}

--- a/MailerQ/RestApi/RestApiException.cs
+++ b/MailerQ/RestApi/RestApiException.cs
@@ -1,0 +1,44 @@
+﻿using System;
+
+namespace MailerQ.RestApi
+{
+    /// <summary>
+    /// Represents errors that occur executing the Rest API Client.
+    /// </summary>
+    [Serializable]
+    public class RestApiException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the MailerQ.RestApi.RestApiException class.
+        /// </summary>
+        public RestApiException() { }
+
+        /// <summary>
+        /// Initializes a new instance of the MailerQ.RestApi.RestApiException class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public RestApiException(string message) : base(message) { }
+
+        /// <summary>
+        /// Initializes a new instance of the MailerQ.RestApi.RestApiException class with a specified error message.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        /// <param name="inner">
+        /// The exception that is the cause of the current exception, or a null reference if no inner exception is specified.
+        /// </param>
+        public RestApiException(string message, Exception inner) : base(message, inner) { }
+
+        /// <summary>
+        /// Initializes a new instance of the MailerQ.RestApi.RestApiException class with a specified error message.
+        /// </summary>
+        /// <param name="info">
+        /// The System.Runtime.Serialization.SerializationInfo that holds the serialized object data about the exception being thrown
+        /// </param>
+        /// <param name="context">
+        /// The System.Runtime.Serialization.StreamingContext that contains contextual information about the source or destination.
+        /// </param>
+        protected RestApiException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/MailerQ/RestApi/RestApiResponse.cs
+++ b/MailerQ/RestApi/RestApiResponse.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Net;
+
+namespace MailerQ.RestApi
+{
+    /// <summary>
+    /// A generic MailerQ Rest API response
+    /// </summary>
+    /// <typeparam name="T">Model type that return the endpoint</typeparam>
+    public class RestApiResponse<T> : IRestApiResponse<T> where T : IRestApiModel
+    {
+        /// <inheritdoc />
+        public HttpStatusCode HttpStatusCode { get; }
+
+        /// <inheritdoc />
+        public ICollection<T> Content { get; }
+
+        /// <summary>
+        /// Initializes a new instance of generic MailerQ Rest API response
+        /// </summary>
+        /// <param name="httpStatusCode">The HTTP status code of the response</param>
+        /// <param name="content">Collection of object deserialized from the response content</param>
+        public RestApiResponse(HttpStatusCode httpStatusCode, ICollection<T> content = default)
+        {
+            HttpStatusCode = httpStatusCode;
+            Content = content;
+        }
+    }
+}

--- a/MailerQ/RestApi/Suppression.cs
+++ b/MailerQ/RestApi/Suppression.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace MailerQ.RestApi
 {
@@ -35,6 +36,7 @@ namespace MailerQ.RestApi
         /// <summary>
         /// ("address", "domain")	Whether the given value is a domain or a full address
         /// </summary>
+        [JsonConverter(typeof(StringEnumConverter), typeof(LowercaseNamingStrategy))]
         public SuppressionTypes Type { get; set; }
 
         /// <summary>

--- a/MailerQ/RestApi/Suppression.cs
+++ b/MailerQ/RestApi/Suppression.cs
@@ -24,7 +24,7 @@ namespace MailerQ.RestApi
         NamingStrategyType = typeof(LowercaseNamingStrategy),
         ItemNullValueHandling = NullValueHandling.Ignore
     )]
-    public class Suppression
+    public class Suppression : IRestApiModel
     {
         /// <summary>
         /// The domain or address to be suppressed


### PR DESCRIPTION
This PR is for add a _dotnet_ client for [MailerQ Rest Api](https://www.mailerq.com/documentation/5.13/rest-api-v1)

Inspired in #33 

- [x] Allow `CancellationToken` parameter