### PR TITLE
chore: rename actions from publish to delivery

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -14,11 +14,11 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.102
+        dotnet-version: '5.0.x'
     - name: Restore tools
       run: dotnet tool restore
     - name: Verify code format
-      run: dotnet dotnet-format --dry-run --check
+      run: dotnet dotnet-format --check
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Test with dotnet
@@ -33,6 +33,6 @@ jobs:
         name: artifacts
         path: ./artifacts
     - name: Publish to AppVeyor nuget registry
-      run: dotnet nuget push **\*.nupkg -Source 'https://ci.appveyor.com/nuget/makingsense-aspnet/api/v2/package' -ApiKey ${{secrets.APPVEYOR_NUGET_API_KEY}}
+      run: dotnet nuget push ./artifacts/*.nupkg -Source 'https://ci.appveyor.com/nuget/makingsense-aspnet/api/v2/package' -ApiKey ${{secrets.APPVEYOR_NUGET_API_KEY}}
     - name: Publish to github
       run: dotnet nuget push "./artifacts/MailerQ.${VERSION:1}.nupkg" --source 'github'


### PR DESCRIPTION
This delivery the nuget package.
Update to net 5
fix dotnet-format