### PR TITLE
feat: allow dkim oversign headers

### DIFF
--- a/MailerQ/Dkim.cs
+++ b/MailerQ/Dkim.cs
@@ -52,5 +52,10 @@ namespace MailerQ
         /// A DKIM can be signed using different forms of canonicalization. Default is relaxed/simple.
         /// </summary>
         public string Canonicalization { get; set; }
+
+        /// <summary>
+        /// Oversign headers
+        /// </summary>
+        public bool? Oversign { get; set; }
     }
 }


### PR DESCRIPTION
This adds a new property for _Dkim_ block of `OutgoingMessage` to instruct _MailerQ_ over-sign headers with the Dkim

This property is not documented in https://www.mailerq.com/documentation/ and was identify by us from database columns and management UI