### PR TITLE
[DD-966] allow inject OutbounMessage directly to the api

### DIFF
--- a/MailerQ.Test/RestApiClientTest.cs
+++ b/MailerQ.Test/RestApiClientTest.cs
@@ -66,6 +66,7 @@ namespace MailerQ.RestApi.Test
         public static IEnumerable<object[]> RestApiModelSpecimens()
         {
             yield return new object[] { specimens.Create<Inject>() };
+            yield return new object[] { specimens.Create<OutgoingMessage>() };
             yield return new object[] { specimens.Create<Pause>() };
             yield return new object[] { specimens.Create<Error>() };
             yield return new object[] { specimens.Create<Pool>() };
@@ -80,6 +81,7 @@ namespace MailerQ.RestApi.Test
         public static IEnumerable<object[]> RestApiModelEndpointSpecimens()
         {
             yield return new object[] { specimens.Create<Inject>(), $"{Version}/inject" };
+            yield return new object[] { specimens.Create<OutgoingMessage>(), $"{Version}/inject" };
             yield return new object[] { specimens.Create<Pause>(), $"{Version}/pauses" };
             yield return new object[] { specimens.Create<Error>(), $"{Version}/errors" };
             yield return new object[] { specimens.Create<Pool>(), $"{Version}/pools" };

--- a/MailerQ/OutgoingMessage.cs
+++ b/MailerQ/OutgoingMessage.cs
@@ -14,6 +14,7 @@ namespace MailerQ
         ItemNullValueHandling = NullValueHandling.Ignore
     )]
     public class OutgoingMessage
+        : RestApi.IRestApiModel
     {
         /// <summary>
         /// Unique message id generated for the mail

--- a/MailerQ/RestApi/RestApiClient.cs
+++ b/MailerQ/RestApi/RestApiClient.cs
@@ -50,7 +50,7 @@ namespace MailerQ.RestApi
 
             var endpointName = $"{typeName.ToLowerInvariant()}s";
 
-            if (type == typeof(Inject))
+            if (type == typeof(Inject) || type == typeof(OutgoingMessage))
             {
                 endpointName = "inject";
             }


### PR DESCRIPTION
This allow inject an instance of `OutgoingMessage` without require convert to the `Inject` type that is a derived class of `OutgoingMessage` to interact with the logic of _MailerQ API_